### PR TITLE
Add runtime dependencies needed to run a langserver "built from source"

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,11 @@ To setup the repo locally run:
 git clone --recursive https://github.com/vscode-langservers/vscode-css-languageserver-bin
 cd vscode-css-languageserver-bin
 npm install
-npm run pack
+npm run build
 ```
+This will produce `*.js` files, including the primary executable `cssServerMain.js`, in a folder named `dist`.
+
+Run `node /path/to/dist/cssServerMain.js`, with or without arguments, to start the language server.
 
 ## Versioning
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,62 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
       "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
       "dev": true
+    },
+    "vscode-css-languageservice": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-3.0.12.tgz",
+      "integrity": "sha512-+FLQ9LcukIhnxaGTjDOqb3Nb1hesz9BLXf5yeoZxUsuK7joADPLPdxLwlZugFcMAvgmtnaFIGnzkQhGOVqf5yw==",
+      "requires": {
+        "vscode-languageserver-types": "^3.13.0",
+        "vscode-nls": "^4.0.0"
+      }
+    },
+    "vscode-jsonrpc": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
+      "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
+    },
+    "vscode-languageserver": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-5.1.0.tgz",
+      "integrity": "sha512-CIsrgx2Y5VHS317g/HwkSTWYBIQmy0DwEyZPmB2pEpVOhYFwVsYpbiJwHIIyLQsQtmRaO4eA2xM8KPjNSdXpBw==",
+      "requires": {
+        "vscode-languageserver-protocol": "3.13.0",
+        "vscode-uri": "^1.0.6"
+      }
+    },
+    "vscode-languageserver-protocol": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.13.0.tgz",
+      "integrity": "sha512-2ZGKwI+P2ovQll2PGAp+2UfJH+FK9eait86VBUdkPd9HRlm8e58aYT9pV/NYanHOcp3pL6x2yTLVCFMcTer0mg==",
+      "requires": {
+        "vscode-jsonrpc": "^4.0.0",
+        "vscode-languageserver-types": "3.13.0"
+      }
+    },
+    "vscode-languageserver-protocol-foldingprovider": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol-foldingprovider/-/vscode-languageserver-protocol-foldingprovider-2.0.1.tgz",
+      "integrity": "sha512-N8bOS8i0xuQMn/y0bijyefDbOsMl6hiH6LDREYWavTLTM5jbj44EiQfStsbmAv/0eaFKkL/jf5hW7nWwBy2HBw==",
+      "requires": {
+        "vscode-languageserver-protocol": "^3.7.2",
+        "vscode-languageserver-types": "^3.7.2"
+      }
+    },
+    "vscode-languageserver-types": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.13.0.tgz",
+      "integrity": "sha512-BnJIxS+5+8UWiNKCP7W3g9FlE7fErFw0ofP5BXJe7c2tl0VeWh+nNHFbwAS2vmVC4a5kYxHBjRy0UeOtziemVA=="
+    },
+    "vscode-nls": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.0.0.tgz",
+      "integrity": "sha512-qCfdzcH+0LgQnBpZA53bA32kzp9rpq/f66Som577ObeuDlFIrtbEJ+A/+CCxjIh4G8dpJYNCKIsxpRAHIfsbNw=="
+    },
+    "vscode-uri": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.6.tgz",
+      "integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,5 +24,10 @@
     "publish": "npm run build && npm publish dist",
     "pack": "npm run build && npm pack dist",
     "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "vscode-css-languageservice": "^3.0.12",
+    "vscode-languageserver": "^5.1.0",
+    "vscode-languageserver-protocol-foldingprovider": "^2.0.1"
   }
 }


### PR DESCRIPTION
Adds npm packages to `package.json` that are needed to run the transpiled `cssServerMain.js` file from the command line, e.g. with: `node ~/vscode-css-languageserver-bin/dist/cssServerMain.js --stdio`. These additional dependencies are installed when running `npm install`.